### PR TITLE
Generalize to handle all branches in the local repo

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,12 +27,12 @@ async function hasPushAccess (context, params) {
 
 module.exports = (robot) => {
   robot.on('pull_request.opened', async context => {
-    const repoName = context.payload.repository.name
+    const {repo} = context.repo()
     const branchLabel = context.payload.pull_request.head.label
 
     // If the branch label starts with the repo name, then it is a PR from a branch in the local
     // repo
-    if (branchLabel.startsWith(repoName)) {
+    if (branchLabel.startsWith(repo)) {
       const canPush = await hasPushAccess(context.repo({username: context.payload.pull_request.user.login}))
 
       // If the user creating the PR from a local branch doesn't have push access, then they

--- a/index.js
+++ b/index.js
@@ -27,17 +27,22 @@ async function hasPushAccess (context, params) {
 
 module.exports = (robot) => {
   robot.on('pull_request.opened', async context => {
-    const {repo} = context.repo()
+    const {owner} = context.repo()
     const branchLabel = context.payload.pull_request.head.label
 
-    // If the branch label starts with the repo name, then it is a PR from a branch in the local
+    // If the branch label starts with the owner name, then it is a PR from a branch in the local
     // repo
-    if (branchLabel.startsWith(repo)) {
-      const canPush = await hasPushAccess(context.repo({username: context.payload.pull_request.user.login}))
+    if (branchLabel.startsWith(owner)) {
+      robot.log.debug(`PR created from branch in the local repo`)
+
+      const username = context.payload.pull_request.user.login
+      const canPush = await hasPushAccess(context, context.repo({username}))
 
       // If the user creating the PR from a local branch doesn't have push access, then they
       // can't push to their own PR and it isn't going to be useful
       if (!canPush) {
+        robot.log.debug(`PR created from repo branch and user cannot push - closing PR`)
+
         await comment(context, context.issue({body: commentBody}))
 
         return close(context, context.issue())

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "standard"
   },
   "dependencies": {
-    "probot": "^0.10.0"
+    "probot": "^0.11.0"
   },
   "devDependencies": {
     "chai": "^4.1.1",


### PR DESCRIPTION
Now checks:

1. If the branch the PR represents is from the local repo
1. If the user does not have push access to the repo

If both of the above are true, then this is typically a mistake and should be closed.